### PR TITLE
Modifications to CNI flags and deployment

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -140,7 +140,7 @@ func NewClient(cluster string) (client.Client, error) {
 
 // FinalizeSetup creates custom environment
 func FinalizeSetup(config *Config, box *packr.Box) error {
-	masterIP, err := GetMasterDockerIP(cl.Name)
+	masterIP, err := GetMasterDockerIP(config.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -139,111 +139,43 @@ func NewClient(cluster string) (client.Client, error) {
 }
 
 // FinalizeSetup creates custom environment
-func FinalizeSetup(cl *Config, box *packr.Box) error {
+func FinalizeSetup(config *Config, box *packr.Box) error {
 	masterIP, err := GetMasterDockerIP(cl.Name)
 	if err != nil {
 		return err
 	}
 
-	err = PrepareKubeConfigs(cl.Name, cl.KubeConfigFilePath, masterIP)
+	err = PrepareKubeConfigs(config.Name, config.KubeConfigFilePath, masterIP)
 	if err != nil {
 		return err
 	}
 
-	client, err := NewClient(cl.Name)
+	client, err := NewClient(config.Name)
 	if err != nil {
 		return err
 	}
 
-	switch cl.Cni {
-	case "calico":
-		calicoDeploymentFile, err := GenerateCalicoDeploymentFile(cl, box)
-		if err != nil {
-			return err
-		}
-
-		calicoCrdFile, err := box.Resolve("tpl/calico-crd.yaml")
-		if err != nil {
-			return err
-		}
-
-		err = deploy.Resources(cl.Name, client, calicoCrdFile.String(), "Calico CRD")
-		if err != nil {
-			return err
-		}
-
-		err = deploy.Resources(cl.Name, client, calicoDeploymentFile, "Calico")
-		if err != nil {
-			return err
-		}
-
-		err = wait.ForDaemonSetReady(cl.Name, client, "kube-system", "calico-node")
-		if err != nil {
-			return err
-		}
-
-		err = wait.ForDeploymentReady(cl.Name, client, "kube-system", "coredns")
-		if err != nil {
-			return err
-		}
-	case "flannel":
-		flannelDeploymentFile, err := GenerateFlannelDeploymentFile(cl, box)
-		if err != nil {
-			return err
-		}
-
-		err = deploy.Resources(cl.Name, client, flannelDeploymentFile, "Flannel")
-		if err != nil {
-			return err
-		}
-
-		err = wait.ForDaemonSetReady(cl.Name, client, "kube-system", "kube-flannel-ds-amd64")
-		if err != nil {
-			return err
-		}
-
-		err = wait.ForDeploymentReady(cl.Name, client, "kube-system", "coredns")
-		if err != nil {
-			return err
-		}
-	case "weave":
-		weaveDeploymentFile, err := GenerateWeaveDeploymentFile(cl, box)
-		if err != nil {
-			return err
-		}
-
-		err = deploy.Resources(cl.Name, client, weaveDeploymentFile, "Weave")
-		if err != nil {
-			return err
-		}
-
-		err = wait.ForDaemonSetReady(cl.Name, client, "kube-system", "weave-net")
-		if err != nil {
-			return err
-		}
-
-		err = wait.ForDeploymentReady(cl.Name, client, "kube-system", "coredns")
-		if err != nil {
-			return err
-		}
+	err = DeployCni(config, box, client)
+	if err != nil {
+		return err
 	}
 
-	if cl.Tiller {
+	if config.Tiller {
 		tillerDeploymentFile, err := box.Resolve("helm/tiller-deployment.yaml")
 		if err != nil {
 			return err
 		}
 
-		err = deploy.Resources(cl.Name, client, tillerDeploymentFile.String(), "Tiller")
+		err = deploy.Resources(config.Name, client, tillerDeploymentFile.String(), "Tiller")
 		if err != nil {
 			return err
 		}
 
-		err = wait.ForDeploymentReady(cl.Name, client, "kube-system", "tiller-deploy")
+		err = wait.ForDeploymentReady(config.Name, client, "kube-system", "tiller-deploy")
 		if err != nil {
 			return err
 		}
 	}
-	log.Infof("✔ Cluster %q is ready 🔥🔥🔥", cl.Name)
+	log.Infof("✔ Cluster %q is ready 🔥🔥🔥", config.Name)
 	return nil
 }

--- a/pkg/cluster/cluster_suite_test.go
+++ b/pkg/cluster/cluster_suite_test.go
@@ -15,6 +15,6 @@ func TestCluster(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	defaults.WaitDurationResources = 1 * time.Minute
+	defaults.WaitDurationResources = 10 * time.Second
 	defaults.WaitRetryPeriod = 200 * time.Millisecond
 })

--- a/pkg/cluster/cluster_suite_test.go
+++ b/pkg/cluster/cluster_suite_test.go
@@ -1,0 +1,20 @@
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/armada/pkg/defaults"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster test suite")
+}
+
+var _ = BeforeSuite(func() {
+	defaults.WaitDurationResources = 1 * time.Minute
+	defaults.WaitRetryPeriod = 200 * time.Millisecond
+})

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -17,11 +17,6 @@ import (
 	kind "sigs.k8s.io/kind/pkg/cluster"
 )
 
-func TestCluster(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Cluster test suite")
-}
-
 var _ = Describe("cluster tests", func() {
 	Context("Containers", func() {
 		ctx := context.Background()

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"

--- a/pkg/cluster/cni.go
+++ b/pkg/cluster/cni.go
@@ -2,11 +2,116 @@ package cluster
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 
 	"github.com/gobuffalo/packr/v2"
 	"github.com/pkg/errors"
+	"github.com/submariner-io/armada/pkg/deploy"
+	"github.com/submariner-io/armada/pkg/wait"
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/kubernetes"
 )
+
+const (
+	Calico  = "calico"
+	Flannel = "flannel"
+	Kindnet = "kindnet"
+	Weave   = "weave"
+)
+
+type deployCniFunc func(config *Config, box *packr.Box, clientSet kubernetes.Interface, apiExtClientSet apiextclientset.Interface) error
+
+var (
+	CNIs = []string{Calico, Flannel, Kindnet, Weave}
+
+	cniDeployers = map[string]deployCniFunc{Calico: deployCalico, Flannel: deployFlannel, Weave: deployWeave, Kindnet: deployKindnet}
+)
+
+func DeployCni(config *Config, box *packr.Box, clientSet kubernetes.Interface, apiExtClientSet apiextclientset.Interface) error {
+	deployCni, exists := cniDeployers[config.Cni]
+	if !exists {
+		return fmt.Errorf("Invalid CNI name %q", config.Cni)
+	}
+
+	return deployCni(config, box, clientSet, apiExtClientSet)
+}
+
+func deployFlannel(config *Config, box *packr.Box, clientSet kubernetes.Interface, apiExtClientSet apiextclientset.Interface) error {
+	flannelDeploymentFile, err := GenerateFlannelDeploymentFile(config, box)
+	if err != nil {
+		return err
+	}
+
+	err = deploy.Resources(config.Name, clientSet, flannelDeploymentFile, "Flannel")
+	if err != nil {
+		return err
+	}
+
+	err = wait.ForDaemonSetReady(config.Name, clientSet, "kube-system", "kube-flannel-ds-amd64")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deployCalico(config *Config, box *packr.Box, clientSet kubernetes.Interface, apiExtClientSet apiextclientset.Interface) error {
+	calicoDeploymentFile, err := GenerateCalicoDeploymentFile(config, box)
+	if err != nil {
+		return err
+	}
+
+	calicoCrdFile, err := box.Resolve("tpl/calico-crd.yaml")
+	if err != nil {
+		return err
+	}
+
+	err = deploy.CrdResources(config.Name, apiExtClientSet, calicoCrdFile.String())
+	if err != nil {
+		return err
+	}
+
+	err = deploy.Resources(config.Name, clientSet, calicoDeploymentFile, "Calico")
+	if err != nil {
+		return err
+	}
+
+	err = wait.ForDaemonSetReady(config.Name, clientSet, "kube-system", "calico-node")
+	if err != nil {
+		return err
+	}
+
+	err = wait.ForDeploymentReady(config.Name, clientSet, "kube-system", "calico-kube-controllers")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deployWeave(config *Config, box *packr.Box, clientSet kubernetes.Interface, apiExtClientSet apiextclientset.Interface) error {
+	weaveDeploymentFile, err := GenerateWeaveDeploymentFile(config, box)
+	if err != nil {
+		return err
+	}
+
+	err = deploy.Resources(config.Name, clientSet, weaveDeploymentFile, "Weave")
+	if err != nil {
+		return err
+	}
+
+	err = wait.ForDaemonSetReady(config.Name, clientSet, "kube-system", "weave-net")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deployKindnet(config *Config, box *packr.Box, clientSet kubernetes.Interface, apiExtClientSet apiextclientset.Interface) error {
+	return nil
+}
 
 // GenerateCalicoDeploymentFile generates calico deployment file from template
 func GenerateCalicoDeploymentFile(config *Config, box *packr.Box) (string, error) {

--- a/pkg/cluster/cni_test.go
+++ b/pkg/cluster/cni_test.go
@@ -9,6 +9,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/armada/pkg/cluster"
+	appsv1 "k8s.io/api/apps/v1"
+	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	fakeApiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 )
 
 var _ = Describe("CNI tests", func() {
@@ -40,7 +48,128 @@ var _ = Describe("CNI tests", func() {
 			verifyDeployment(actual, "calico_deployment.golden")
 		})
 	})
+
+	Context("CNI deployment", func() {
+		testDeployCNIs(box)
+	})
 })
+
+func testDeployCNIs(box *packr.Box) {
+	var (
+		clientSet       kubernetes.Interface
+		apiExtClientSet apiextclientset.Interface
+		config          *cluster.Config
+		stopCh          chan struct{}
+		deployErr       error
+	)
+
+	BeforeEach(func() {
+		clientSet = fake.NewSimpleClientset()
+		apiExtClientSet = fakeApiext.NewSimpleClientset()
+		stopCh = make(chan struct{})
+
+		config = &cluster.Config{
+			Name:      "east",
+			PodSubnet: "1.2.3.4/8",
+		}
+	})
+
+	AfterEach(func() {
+		close(stopCh)
+	})
+
+	JustBeforeEach(func() {
+		factory := informers.NewSharedInformerFactory(clientSet, 0)
+		factory.Apps().V1().Deployments().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				d := obj.(*appsv1.Deployment)
+				d.Status.ReadyReplicas = *d.Spec.Replicas
+				_, _ = clientSet.AppsV1().Deployments(d.Namespace).Update(d)
+			},
+		})
+
+		factory.Apps().V1().DaemonSets().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				d := obj.(*appsv1.DaemonSet)
+				d.Status.DesiredNumberScheduled = 1
+				d.Status.NumberReady = d.Status.DesiredNumberScheduled
+				_, _ = clientSet.AppsV1().DaemonSets(d.Namespace).Update(d)
+			},
+		})
+
+		factory.Start(stopCh)
+
+		deployErr = cluster.DeployCni(config, box, clientSet, apiExtClientSet)
+	})
+
+	When("the weave CNI is specified", func() {
+		BeforeEach(func() {
+			config.Cni = cluster.Weave
+		})
+
+		It("should create the weave-net DaemonSet", func() {
+			Expect(deployErr).To(Succeed())
+			ds := getDaemonSetByLabel("name=weave-net", clientSet)
+			Expect(ds.Spec.Template.Spec.Containers[0].Image).Should(Equal("docker.io/weaveworks/weave-kube:2.6.0"))
+			Expect(ds.Spec.Template.Spec.Containers[0].Env[1].Value).Should(Equal(config.PodSubnet))
+		})
+	})
+
+	When("the flannel CNI is specified", func() {
+		BeforeEach(func() {
+			config.Cni = cluster.Flannel
+		})
+
+		It("should create the flannel DaemonSet and kube-flannel-cfg ConfigMap", func() {
+			Expect(deployErr).To(Succeed())
+			ds := getDaemonSetByLabel("app=flannel", clientSet)
+			Expect(ds.Spec.Template.Spec.Containers[0].Image).Should(Equal("quay.io/coreos/flannel:v0.11.0-amd64"))
+
+			cm, err := clientSet.CoreV1().ConfigMaps("kube-system").Get("kube-flannel-cfg", metav1.GetOptions{})
+			Expect(err).To(Succeed())
+			Expect(cm.Data["net-conf.json"]).To(ContainSubstring(config.PodSubnet))
+		})
+	})
+
+	When("the calico CNI is specified", func() {
+		BeforeEach(func() {
+			config.Cni = cluster.Calico
+		})
+
+		It("should create the calico-node DaemonSet and the calico-kube-controllers Deployment", func() {
+			Expect(deployErr).To(Succeed())
+			ds := getDaemonSetByLabel("k8s-app=calico-node", clientSet)
+			Expect(ds.Spec.Template.Spec.Containers[0].Image).Should(Equal("calico/node:v3.9.3"))
+			Expect(ds.Spec.Template.Spec.Containers[0].Env[8].Value).Should(Equal(config.PodSubnet))
+
+			getDeploymentByLabel("k8s-app=calico-kube-controllers", clientSet)
+		})
+	})
+
+	When("an invalid CNI name is specified", func() {
+		BeforeEach(func() {
+			config.Cni = "bogus"
+		})
+
+		It("should return an error", func() {
+			Expect(deployErr).To(HaveOccurred())
+		})
+	})
+}
+
+func getDaemonSetByLabel(label string, clientSet kubernetes.Interface) *appsv1.DaemonSet {
+	list, err := clientSet.AppsV1().DaemonSets("kube-system").List(metav1.ListOptions{LabelSelector: label})
+	Expect(err).To(Succeed())
+	Expect(list.Items).To(HaveLen(1))
+	return &list.Items[0]
+}
+
+func getDeploymentByLabel(label string, clientSet kubernetes.Interface) *appsv1.Deployment {
+	list, err := clientSet.AppsV1().Deployments("kube-system").List(metav1.ListOptions{LabelSelector: label})
+	Expect(err).To(Succeed())
+	Expect(list.Items).To(HaveLen(1))
+	return &list.Items[0]
+}
 
 func verifyDeployment(actualDeploymentContents string, expDeploymentFileName string) {
 	currentDir, err := os.Getwd()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -34,9 +34,14 @@ const (
 	// LocalKubeConfigDir is a default  kubeconfig files destination directory if running inside container
 	ContainerKubeConfigDir = "output/kube-config/container"
 
+	// KubeAdminAPIVersion is a default version used by in kind configs
+	KubeAdminAPIVersion = "kubeadm.k8s.io/v1beta2"
+)
+
+var (
 	// WaitDurationResources is a default timeout for waiter functions
 	WaitDurationResources = time.Duration(10) * time.Minute
 
-	// KubeAdminAPIVersion is a default version used by in kind configs
-	KubeAdminAPIVersion = "kubeadm.k8s.io/v1beta2"
+	// WaitRetryPeriod is the amount oof time between retries for waiter functions
+	WaitRetryPeriod = 2 * time.Second
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -34,7 +34,7 @@ const (
 	// LocalKubeConfigDir is a default  kubeconfig files destination directory if running inside container
 	ContainerKubeConfigDir = "output/kube-config/container"
 
-	// KubeAdminAPIVersion is a default version used by in kind configs
+	// KubeAdminAPIVersion is a default version used in kind configs
 	KubeAdminAPIVersion = "kubeadm.k8s.io/v1beta2"
 )
 
@@ -42,6 +42,6 @@ var (
 	// WaitDurationResources is a default timeout for waiter functions
 	WaitDurationResources = time.Duration(10) * time.Minute
 
-	// WaitRetryPeriod is the amount oof time between retries for waiter functions
+	// WaitRetryPeriod is the amount of time between retries for waiter functions
 	WaitRetryPeriod = 2 * time.Second
 )

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -50,7 +49,7 @@ func ForPodsRunning(clName string, c client.Client, namespace, selector string, 
 		} else {
 			log.Infof("Still waiting for pods with label %q, namespace %q, replicas %v in cluster: %q.", selector, namespace, replicas, clName)
 		}
-	}, 2*time.Second, podsContext.Done())
+	}, defaults.WaitRetryPeriod, podsContext.Done())
 
 	err = podsContext.Err()
 	if err != nil && err != context.Canceled {
@@ -79,7 +78,7 @@ func ForDeploymentReady(clName string, c client.Client, namespace, deploymentNam
 		} else {
 			log.Errorf("Error getting deployment %q in cluster %q: %v", deploymentName, clName, err)
 		}
-	}, 2*time.Second, deploymentContext.Done())
+	}, defaults.WaitRetryPeriod, deploymentContext.Done())
 
 	err := deploymentContext.Err()
 	if err != nil && err != context.Canceled {
@@ -97,8 +96,8 @@ func ForDaemonSetReady(clName string, c client.Client, namespace, daemonSetName 
 		daemonSet := &appsv1.DaemonSet{}
 		err := c.Get(context.TODO(), types.NamespacedName{Name: daemonSetName, Namespace: namespace}, daemonSet)
 		if err == nil {
-			if daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled {
-				log.Infof("✔ Daemon set %q successfully rolled out %v replicas in cluster %q", daemonSetName, clName, daemonSet.Status.NumberReady)
+			if daemonSet.Status.DesiredNumberScheduled > 0 && daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled {
+				log.Infof("✔ Daemon set %q successfully rolled out %v replicas in cluster %q", daemonSetName, daemonSet.Status.NumberReady, clName)
 				cancel()
 			} else {
 				log.Infof("Still waiting for daemon set %q roll out in cluster %q, %v out of %v replicas ready", daemonSetName, clName, daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled)
@@ -108,7 +107,7 @@ func ForDaemonSetReady(clName string, c client.Client, namespace, daemonSetName 
 		} else {
 			log.Errorf("Error getting daemon set %q in cluster %q: %v", daemonSetName, clName, err)
 		}
-	}, 2*time.Second, deploymentContext.Done())
+	}, defaults.WaitRetryPeriod, deploymentContext.Done())
 
 	err := deploymentContext.Err()
 	if err != nil && err != context.Canceled {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -89,7 +89,7 @@ var _ = Describe("E2E Tests", func() {
 			flags := &clustercmd.CreateFlagpole{
 				NumClusters: 2,
 				Overlap:     true,
-				Flannel:     true,
+				Cni:         cluster.Flannel,
 				Retain:      false,
 				Wait:        5 * time.Minute,
 			}
@@ -135,7 +135,7 @@ var _ = Describe("E2E Tests", func() {
 		It("Should create a third cluster with weave, kindest/node:v1.15.6 and tiller", func() {
 			flags := &clustercmd.CreateFlagpole{
 				NumClusters: 3,
-				Weave:       true,
+				Cni:         cluster.Weave,
 				Tiller:      true,
 				ImageName:   "kindest/node:v1.15.6",
 				Retain:      false,


### PR DESCRIPTION
Replaced the individual CNI flags with a single --cni option.

To streamline CNI deployment, elminated the large switch in
FinalizeSetup and added a map that contains specific CNI deployment
functions keyed by CNI name. This will make it easier for
extending it to support other CNIs.

Added UT's to cover the new code.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>