### PR TITLE
Fix intermittent E2E failure

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -7,7 +7,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -25,7 +24,7 @@ import (
 )
 
 // Create creates cluster with kind
-func Create(cl *Config, provider *kind.Provider, box *packr.Box, wg *sync.WaitGroup) error {
+func Create(cl *Config, provider *kind.Provider, box *packr.Box) error {
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -67,7 +66,7 @@ func Create(cl *Config, provider *kind.Provider, box *packr.Box, wg *sync.WaitGr
 		}
 		return errors.Wrap(err, "failed to create cluster")
 	}
-	wg.Done()
+
 	return nil
 }
 
@@ -140,7 +139,7 @@ func NewClient(cluster string) (client.Client, error) {
 }
 
 // FinalizeSetup creates custom environment
-func FinalizeSetup(cl *Config, box *packr.Box, wg *sync.WaitGroup) error {
+func FinalizeSetup(cl *Config, box *packr.Box) error {
 	masterIP, err := GetMasterDockerIP(cl.Name)
 	if err != nil {
 		return err
@@ -246,6 +245,5 @@ func FinalizeSetup(cl *Config, box *packr.Box, wg *sync.WaitGroup) error {
 		}
 	}
 	log.Infof("✔ Cluster %q is ready 🔥🔥🔥", cl.Name)
-	wg.Done()
 	return nil
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -107,7 +106,7 @@ func Save(ctx context.Context, dockerCli *dockerclient.Client, imageName string)
 }
 
 // LoadToNode loads an image to kubernetes node
-func LoadToNode(imageTarPath, imageName string, node nodes.Node, wg *sync.WaitGroup) error {
+func LoadToNode(imageTarPath, imageName string, node nodes.Node) error {
 	f, err := os.Open(imageTarPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open an image: %s, location: %q", imageName, imageTarPath)
@@ -120,6 +119,5 @@ func LoadToNode(imageTarPath, imageName string, node nodes.Node, wg *sync.WaitGr
 		return errors.Wrapf(err, "failed to loading image: %q, node %q", imageName, node.String())
 	}
 	log.Infof("✔ image: %q was loaded to node: %q.", imageName, node.String())
-	wg.Done()
 	return nil
 }

--- a/pkg/wait/wait_test.go
+++ b/pkg/wait/wait_test.go
@@ -1,0 +1,74 @@
+package wait_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/armada/pkg/wait"
+
+	"sync/atomic"
+)
+
+func TestWait(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Wait test suite")
+}
+
+var _ = Describe("Wait tests", func() {
+	Context("ForTasksComplete", testForTasksComplete)
+})
+
+func testForTasksComplete() {
+	When("tasks successfully complete", func() {
+		It("should return success", func() {
+			tasks := []func() error{}
+			numTasks := 5
+			var count uint32
+			for i := 1; i <= numTasks; i++ {
+				tasks = append(tasks, func() error {
+					atomic.AddUint32(&count, 1)
+					return nil
+				})
+			}
+
+			err := wait.ForTasksComplete(10*time.Second, tasks...)
+			Expect(err).To(Succeed())
+			Expect(int(count)).To(Equal(numTasks))
+		})
+	})
+
+	When("a task fails", func() {
+		errMsg := "task failed"
+		It("should return the error", func() {
+			tasks := []func() error{
+				func() error {
+					return nil
+				},
+				func() error {
+					return errors.New(errMsg)
+				},
+			}
+
+			err := wait.ForTasksComplete(10*time.Second, tasks...)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(errMsg))
+		})
+	})
+
+	When("tasks don't complete in time", func() {
+		It("should timeout and return an error", func() {
+			tasks := []func() error{
+				func() error {
+					time.Sleep(5 * time.Second)
+					return nil
+				},
+			}
+
+			err := wait.ForTasksComplete(200*time.Millisecond, tasks...)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}


### PR DESCRIPTION
```
/armada/test/e2e/e2e_test.go:73
  Image loading
  /armada/test/e2e/e2e_test.go:279
    Should load an image to all the clusters [It]
    /armada/test/e2e/e2e_test.go:303

    Expected
        <int>: 8
    to equal
        <int>: 9

    /armada/test/e2e/e2e_test.go:340
```

L340: `Expect(int(nodesWithImage)).To(Equal(9))`

From the output, all 9 images were successfully loaded but the
nodesWithImage length only reported 8 even though it's appended to
right after successful load. The problem is that image loading is
done async and the nodesWithImage isn't protected with a lock. A
similar issue can occur in other areas as well.

Also the goroutines make assertions which isn't really safe with
Gingko.

To alleviate these issues, I created a general wait.ForTasksComplete
function that runs the given task functions async and uses a WaitGroup
too await completion. If a task function returns an error, it aborts the wait and
returns the error. It also times the wait so it can't block forever.

The WaitGroup parameter was removed from cluster.Create and image.LoadToNode
since it's encapsulated by wait.ForTasksComplete.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>