### PR TITLE
Moved out cluster names logic to common utils

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/armada/pkg/cluster"
 	"github.com/submariner-io/armada/pkg/defaults"
+	"github.com/submariner-io/armada/pkg/utils"
 	"github.com/submariner-io/armada/pkg/wait"
 	kind "sigs.k8s.io/kind/pkg/cluster"
 )
@@ -125,15 +125,14 @@ func CreateClusters(flags *CreateFlagpole, provider *kind.Provider, box *packr.B
 }
 
 func persistClusterKubeconfigs(flags *CreateFlagpole) {
-	files, err := ioutil.ReadDir(defaults.KindConfigDir)
+	clusters, err := utils.ClusterNamesFromFiles()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	provider := kind.NewProvider()
 
-	for _, file := range files {
-		clName := strings.FieldsFunc(file.Name(), func(r rune) bool { return strings.ContainsRune(" -.", r) })[2]
+	for _, clName := range clusters {
 		known, err := cluster.IsKnown(clName, provider)
 		if err != nil {
 			log.Error(err)

--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -164,7 +163,7 @@ func persistClusterKubeconfigs(flags *CreateFlagpole) {
 func getTargetClusters(provider *kind.Provider, flags *CreateFlagpole) ([]*cluster.Config, error) {
 	var targetClusters []*cluster.Config
 	for i := 1; i <= flags.NumClusters; i++ {
-		clName := defaults.ClusterNameBase + strconv.Itoa(i)
+		clName := utils.ClusterName(i)
 		known, err := cluster.IsKnown(clName, provider)
 		if err != nil {
 			return nil, err

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -1,13 +1,10 @@
 package cluster
 
 import (
-	"io/ioutil"
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/armada/pkg/cluster"
-	"github.com/submariner-io/armada/pkg/defaults"
+	"github.com/submariner-io/armada/pkg/utils"
 	kind "sigs.k8s.io/kind/pkg/cluster"
 )
 
@@ -25,22 +22,8 @@ func NewDestroyCommand(provider *kind.Provider) *cobra.Command {
 		Short: "Destroy clusters",
 		Long:  "Destroys clusters",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			var targetClusters []string
-			if len(flags.clusters) > 0 {
-				targetClusters = append(targetClusters, flags.clusters...)
-			} else {
-				configFiles, err := ioutil.ReadDir(defaults.KindConfigDir)
-				if err != nil {
-					log.Fatal(err)
-				}
-				for _, configFile := range configFiles {
-					clName := strings.FieldsFunc(configFile.Name(), func(r rune) bool { return strings.ContainsRune(" -.", r) })[2]
-					targetClusters = append(targetClusters, clName)
-				}
-			}
-
-			for _, clName := range targetClusters {
+			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			for _, clName := range clusters {
 				known, err := cluster.IsKnown(clName, provider)
 				if err != nil {
 					log.Fatalf("%s: %v", clName, err)

--- a/cmd/cluster/destroy.go
+++ b/cmd/cluster/destroy.go
@@ -22,7 +22,7 @@ func NewDestroyCommand(provider *kind.Provider) *cobra.Command {
 		Short: "Destroy clusters",
 		Long:  "Destroys clusters",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			clusters := utils.DetermineClusterNames(flags.clusters)
 			for _, clName := range clusters {
 				known, err := cluster.IsKnown(clName, provider)
 				if err != nil {

--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -3,16 +3,15 @@ package image
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	dockerclient "github.com/docker/docker/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/armada/pkg/defaults"
 	"github.com/submariner-io/armada/pkg/image"
+	"github.com/submariner-io/armada/pkg/utils"
 	"github.com/submariner-io/armada/pkg/wait"
 	kind "sigs.k8s.io/kind/pkg/cluster"
 )
@@ -44,27 +43,14 @@ func NewLoadCommand(provider *kind.Provider) *cobra.Command {
 				return err
 			}
 
-			var targetClusters []string
-			if len(flags.clusters) > 0 {
-				targetClusters = append(targetClusters, flags.clusters...)
-			} else {
-				configFiles, err := ioutil.ReadDir(defaults.KindConfigDir)
-				if err != nil {
-					return err
-				}
-				for _, configFile := range configFiles {
-					clName := strings.FieldsFunc(configFile.Name(), func(r rune) bool { return strings.ContainsRune(" -.", r) })[2]
-					targetClusters = append(targetClusters, clName)
-				}
-			}
-
-			if len(targetClusters) > 0 {
+			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			if len(clusters) > 0 {
 				for _, imageName := range flags.images {
 					localImageID, err := image.GetLocalID(ctx, dockerCli, imageName)
 					if err != nil {
 						return err
 					}
-					selectedNodes, err := image.GetNodesWithout(provider, imageName, localImageID, targetClusters)
+					selectedNodes, err := image.GetNodesWithout(provider, imageName, localImageID, clusters)
 					if err != nil {
 						log.Error(err)
 					}

--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -43,7 +43,7 @@ func NewLoadCommand(provider *kind.Provider) *cobra.Command {
 				return err
 			}
 
-			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			clusters := utils.DetermineClusterNames(flags.clusters)
 			if len(clusters) > 0 {
 				for _, imageName := range flags.images {
 					localImageID, err := image.GetLocalID(ctx, dockerCli, imageName)

--- a/cmd/logs/export.go
+++ b/cmd/logs/export.go
@@ -29,7 +29,7 @@ func NewExportCommand(provider *kind.Provider) *cobra.Command {
 			// remove existing before exporting
 			_ = os.RemoveAll(filepath.Join(defaults.KindLogsDir, defaults.KindLogsDir))
 
-			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			clusters := utils.DetermineClusterNames(flags.clusters)
 			for _, clName := range clusters {
 				err := provider.CollectLogs(clName, filepath.Join(defaults.KindLogsDir, clName))
 				if err != nil {

--- a/cmd/netshoot/deploy.go
+++ b/cmd/netshoot/deploy.go
@@ -48,7 +48,7 @@ func NewDeployCommand(box *packr.Box) *cobra.Command {
 				log.Error(err)
 			}
 
-			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			clusters := utils.DetermineClusterNames(flags.clusters)
 			var wg sync.WaitGroup
 			wg.Add(len(clusters))
 			for _, clName := range clusters {

--- a/cmd/netshoot/deploy.go
+++ b/cmd/netshoot/deploy.go
@@ -1,16 +1,14 @@
 package netshoot
 
 import (
-	"io/ioutil"
-	"strings"
 	"sync"
 
 	"github.com/gobuffalo/packr/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/armada/pkg/cluster"
-	"github.com/submariner-io/armada/pkg/defaults"
 	"github.com/submariner-io/armada/pkg/deploy"
+	"github.com/submariner-io/armada/pkg/utils"
 	"github.com/submariner-io/armada/pkg/wait"
 )
 
@@ -50,23 +48,10 @@ func NewDeployCommand(box *packr.Box) *cobra.Command {
 				log.Error(err)
 			}
 
-			var targetClusters []string
-			if len(flags.clusters) > 0 {
-				targetClusters = append(targetClusters, flags.clusters...)
-			} else {
-				configFiles, err := ioutil.ReadDir(defaults.KindConfigDir)
-				if err != nil {
-					log.Fatal(err)
-				}
-				for _, configFile := range configFiles {
-					clName := strings.FieldsFunc(configFile.Name(), func(r rune) bool { return strings.ContainsRune(" -.", r) })[2]
-					targetClusters = append(targetClusters, clName)
-				}
-			}
-
+			clusters := utils.ClusterNamesOrAll(flags.clusters)
 			var wg sync.WaitGroup
-			wg.Add(len(targetClusters))
-			for _, clName := range targetClusters {
+			wg.Add(len(clusters))
+			for _, clName := range clusters {
 				go func(clName string) {
 					client, err := cluster.NewClient(clName)
 					if err != nil {

--- a/cmd/nginx/deploy.go
+++ b/cmd/nginx/deploy.go
@@ -38,7 +38,7 @@ func NewDeployCommand(box *packr.Box) *cobra.Command {
 				log.Error(err)
 			}
 
-			clusters := utils.ClusterNamesOrAll(flags.clusters)
+			clusters := utils.DetermineClusterNames(flags.clusters)
 			var wg sync.WaitGroup
 			wg.Add(len(clusters))
 			for _, clName := range clusters {

--- a/cmd/nginx/deploy.go
+++ b/cmd/nginx/deploy.go
@@ -1,18 +1,16 @@
 package nginx
 
 import (
-	"io/ioutil"
-	"strings"
 	"sync"
 
 	"github.com/submariner-io/armada/pkg/cluster"
 	"github.com/submariner-io/armada/pkg/deploy"
+	"github.com/submariner-io/armada/pkg/utils"
 	"github.com/submariner-io/armada/pkg/wait"
 
 	"github.com/gobuffalo/packr/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/submariner-io/armada/pkg/defaults"
 )
 
 // NginxDeployFlagpole is a list of cli flags for deploy nginx-demo command
@@ -40,23 +38,10 @@ func NewDeployCommand(box *packr.Box) *cobra.Command {
 				log.Error(err)
 			}
 
-			var targetClusters []string
-			if len(flags.clusters) > 0 {
-				targetClusters = append(targetClusters, flags.clusters...)
-			} else {
-				configFiles, err := ioutil.ReadDir(defaults.KindConfigDir)
-				if err != nil {
-					log.Fatal(err)
-				}
-				for _, configFile := range configFiles {
-					clName := strings.FieldsFunc(configFile.Name(), func(r rune) bool { return strings.ContainsRune(" -.", r) })[2]
-					targetClusters = append(targetClusters, clName)
-				}
-			}
-
+			clusters := utils.ClusterNamesOrAll(flags.clusters)
 			var wg sync.WaitGroup
-			wg.Add(len(targetClusters))
-			for _, clName := range targetClusters {
+			wg.Add(len(clusters))
+			for _, clName := range clusters {
 				go func(clName string) {
 					client, err := cluster.NewClient(clName)
 					if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
@@ -196,6 +197,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/submariner-io/armada/pkg/defaults"
+	"github.com/submariner-io/armada/pkg/utils"
 )
 
 // Config type
@@ -116,7 +116,7 @@ func PopulateConfig(clusterNum int, image, cni string, retain, tiller, overlap b
 		return nil, errors.Wrap(err, "failed to get current user information")
 	}
 
-	name := defaults.ClusterNameBase + strconv.Itoa(clusterNum)
+	name := utils.ClusterName(clusterNum)
 	config := &Config{
 		Name:                name,
 		NodeImageName:       image,

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/gobuffalo/packr/v2"
@@ -14,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/armada/pkg/cluster"
 	"github.com/submariner-io/armada/pkg/defaults"
+	"github.com/submariner-io/armada/pkg/utils"
 )
 
 const waitForReady = 5 * time.Minute
@@ -105,7 +105,7 @@ func testPopulateConfig() {
 			user, err := user.Current()
 			Expect(err).To(Succeed())
 
-			name := defaults.ClusterNameBase + strconv.Itoa(1)
+			name := utils.ClusterName(1)
 			Expect(config).Should(Equal(&cluster.Config{
 				Cni:                 "kindnet",
 				Name:                name,
@@ -180,7 +180,7 @@ func testPopulateConfig() {
 				config := executePopulateConfig(i+1, "", "kindnet", false)
 				Expect(config.PodSubnet).To(Equal(expectedPodSubnets[i]))
 				Expect(config.ServiceSubnet).To(Equal(expectedServiceSubnets[i]))
-				Expect(config.Name).To(Equal(defaults.ClusterNameBase + strconv.Itoa(i+1)))
+				Expect(config.Name).To(Equal(utils.ClusterName(i + 1)))
 			}
 		})
 	})

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -25,9 +25,6 @@ const (
 	// KindLogsDir is a default kind log files destination directory
 	KindLogsDir = "output/logs"
 
-	// KindConfigDir is a default kind config files destination directory
-	KindConfigDir = "output/kind-clusters"
-
 	// LocalKubeConfigDir is a default local workstation kubeconfig files destination directory
 	LocalKubeConfigDir = "output/kube-config/local-dev"
 
@@ -39,6 +36,9 @@ const (
 )
 
 var (
+	// KindConfigDir is a default kind config files destination directory
+	KindConfigDir = "output/kind-clusters"
+
 	// WaitDurationResources is a default timeout for waiter functions
 	WaitDurationResources = time.Duration(10) * time.Minute
 

--- a/pkg/utils/cluster_names.go
+++ b/pkg/utils/cluster_names.go
@@ -33,10 +33,10 @@ func ClusterNamesFromFiles() ([]string, error) {
 	return clusters, nil
 }
 
-// ClusterNamesOrAll will return the cluster names sent to it, if there are any.
+// DetermineClusterNames will return the cluster names sent to it, if there are any.
 // In case the slice is empty, it will read the cluster names from the existing kind files.
 // Should the read fail, it will fatally log the error (causing the process to abort).
-func ClusterNamesOrAll(clusters []string) []string {
+func DetermineClusterNames(clusters []string) []string {
 	if len(clusters) > 0 {
 		return clusters
 	}

--- a/pkg/utils/cluster_names.go
+++ b/pkg/utils/cluster_names.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"io/ioutil"
-	"log"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/submariner-io/armada/pkg/defaults"
 )
+
+var logFatal = log.Fatal
 
 // ClusterNamesFromFiles will return all clusters from the existing kind files.
 // An error is returned if there's a failure to read the config directory.
@@ -35,7 +37,7 @@ func ClusterNamesOrAll(clusters []string) []string {
 
 	clusters, err := ClusterNamesFromFiles()
 	if err != nil {
-		log.Fatal(err)
+		logFatal(err)
 	}
 
 	return clusters

--- a/pkg/utils/cluster_names.go
+++ b/pkg/utils/cluster_names.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"io/ioutil"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -9,6 +10,11 @@ import (
 )
 
 var logFatal = log.Fatal
+
+// ClusterName returns the canonical cluster name based on the given number
+func ClusterName(clusterNum int) string {
+	return defaults.ClusterNameBase + strconv.Itoa(clusterNum)
+}
 
 // ClusterNamesFromFiles will return all clusters from the existing kind files.
 // An error is returned if there's a failure to read the config directory.

--- a/pkg/utils/cluster_names_test.go
+++ b/pkg/utils/cluster_names_test.go
@@ -21,9 +21,18 @@ func TestUtils(t *testing.T) {
 }
 
 var _ = Describe("Utils tests", func() {
+	Context("ClusterName", testClusterName)
 	Context("ClusterNamesFromFiles", testClusterNamesFromFiles)
 	Context("ClusterNamesOrAll", testClusterNamesOrAll)
 })
+
+func testClusterName() {
+	When("sent a number", func() {
+		It("should return a cluster name", func() {
+			Expect("cluster42").To(Equal(ClusterName(42)))
+		})
+	})
+}
 
 func stubDirectory() {
 	origDir = defaults.KindConfigDir

--- a/pkg/utils/cluster_names_test.go
+++ b/pkg/utils/cluster_names_test.go
@@ -1,0 +1,168 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/armada/pkg/defaults"
+)
+
+const stubConfigDir = "utils.test.dir"
+
+var origDir string
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils test suite")
+}
+
+var _ = Describe("Utils tests", func() {
+	Context("ClusterNamesFromFiles", testClusterNamesFromFiles)
+	Context("ClusterNamesOrAll", testClusterNamesOrAll)
+})
+
+func stubDirectory() {
+	origDir = defaults.KindConfigDir
+	defaults.KindConfigDir = stubConfigDir
+}
+
+func restoreDirectory() {
+	defaults.KindConfigDir = origDir
+}
+
+func createStubDirectory() {
+	Expect(os.Mkdir(stubConfigDir, 0755)).To(Succeed())
+}
+
+func deleteStubDirectory() {
+	Expect(os.RemoveAll(stubConfigDir)).To(Succeed())
+}
+
+func generateClusterFiles(expectedClusters []string) {
+	for _, cluster := range expectedClusters {
+		fileName := fmt.Sprintf("kind-config-%s.yaml", cluster)
+		_, err := os.Create(filepath.Join(stubConfigDir, fileName))
+		Expect(err).To(Succeed())
+	}
+}
+
+func testClusterNamesFromFiles() {
+	var (
+		clusters []string
+		err      error
+	)
+
+	BeforeEach(stubDirectory)
+
+	AfterEach(restoreDirectory)
+
+	JustBeforeEach(func() {
+		clusters, err = ClusterNamesFromFiles()
+	})
+
+	When("directory doesn't exist", func() {
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	When("directory exists", func() {
+		BeforeEach(createStubDirectory)
+
+		AfterEach(deleteStubDirectory)
+
+		When("the directory is empty", func() {
+			It("should return an empty slice", func() {
+				Expect(len(clusters)).To(Equal(0))
+			})
+		})
+
+		When("the directory has files", func() {
+			var expectedClusters = []string{"cluster1", "cluster2", "cluster42"}
+			BeforeEach(func() {
+				generateClusterFiles(expectedClusters)
+			})
+
+			It("should return the cluster names", func() {
+				Expect(clusters).To(ConsistOf(expectedClusters))
+			})
+		})
+	})
+}
+
+func testClusterNamesOrAll() {
+	var (
+		clusters     []string
+		sentClusters []string
+	)
+
+	BeforeEach(func() {
+		stubDirectory()
+		sentClusters = nil
+	})
+
+	AfterEach(restoreDirectory)
+
+	JustBeforeEach(func() {
+		clusters = ClusterNamesOrAll(sentClusters)
+	})
+
+	When("cluster names are sent", func() {
+		BeforeEach(func() {
+			sentClusters = []string{"cluster13", "cluster76"}
+		})
+		It("should return the sent clusters", func() {
+			Expect(clusters).To(ConsistOf(sentClusters))
+		})
+	})
+
+	When("directory doesn't exist", func() {
+		var (
+			logFatalCalled bool
+			origLogFatal   func(args ...interface{})
+		)
+
+		BeforeEach(func() {
+			logFatalCalled = false
+			origLogFatal = logFatal
+			logFatal = func(args ...interface{}) {
+				logFatalCalled = true
+			}
+		})
+
+		AfterEach(func() {
+			logFatal = origLogFatal
+		})
+
+		It("should call log fatal", func() {
+			Expect(logFatalCalled).To(Equal(true))
+		})
+	})
+
+	When("directory exists", func() {
+		BeforeEach(createStubDirectory)
+
+		AfterEach(deleteStubDirectory)
+
+		When("the directory is empty", func() {
+			It("should return an empty slice", func() {
+				Expect(len(clusters)).To(Equal(0))
+			})
+		})
+
+		When("the directory has files", func() {
+			var expectedClusters = []string{"cluster1", "cluster2", "cluster42"}
+			BeforeEach(func() {
+				generateClusterFiles(expectedClusters)
+			})
+
+			It("should return the cluster names", func() {
+				Expect(clusters).To(ConsistOf(expectedClusters))
+			})
+		})
+	})
+}

--- a/pkg/utils/cluster_names_test.go
+++ b/pkg/utils/cluster_names_test.go
@@ -23,14 +23,12 @@ func TestUtils(t *testing.T) {
 var _ = Describe("Utils tests", func() {
 	Context("ClusterName", testClusterName)
 	Context("ClusterNamesFromFiles", testClusterNamesFromFiles)
-	Context("ClusterNamesOrAll", testClusterNamesOrAll)
+	Context("DetermineClusterNames", testDetermineClusterNames)
 })
 
 func testClusterName() {
-	When("sent a number", func() {
-		It("should return a cluster name", func() {
-			Expect("cluster42").To(Equal(ClusterName(42)))
-		})
+	It("should return the correct cluster name for the given number", func() {
+		Expect("cluster42").To(Equal(ClusterName(42)))
 	})
 }
 
@@ -73,24 +71,24 @@ func testClusterNamesFromFiles() {
 		clusters, err = ClusterNamesFromFiles()
 	})
 
-	When("directory doesn't exist", func() {
+	When("the directory doesn't exist", func() {
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	When("directory exists", func() {
+	When("the directory exists", func() {
 		BeforeEach(createStubDirectory)
 
 		AfterEach(deleteStubDirectory)
 
-		When("the directory is empty", func() {
+		Context("and is empty", func() {
 			It("should return an empty slice", func() {
 				Expect(len(clusters)).To(Equal(0))
 			})
 		})
 
-		When("the directory has files", func() {
+		Context("and contains files", func() {
 			var expectedClusters = []string{"cluster1", "cluster2", "cluster42"}
 			BeforeEach(func() {
 				generateClusterFiles(expectedClusters)
@@ -103,7 +101,7 @@ func testClusterNamesFromFiles() {
 	})
 }
 
-func testClusterNamesOrAll() {
+func testDetermineClusterNames() {
 	var (
 		clusters     []string
 		sentClusters []string
@@ -117,19 +115,19 @@ func testClusterNamesOrAll() {
 	AfterEach(restoreDirectory)
 
 	JustBeforeEach(func() {
-		clusters = ClusterNamesOrAll(sentClusters)
+		clusters = DetermineClusterNames(sentClusters)
 	})
 
-	When("cluster names are sent", func() {
+	When("cluster names are provided", func() {
 		BeforeEach(func() {
 			sentClusters = []string{"cluster13", "cluster76"}
 		})
-		It("should return the sent clusters", func() {
+		It("should return the provided clusters", func() {
 			Expect(clusters).To(ConsistOf(sentClusters))
 		})
 	})
 
-	When("directory doesn't exist", func() {
+	When("the directory doesn't exist", func() {
 		var (
 			logFatalCalled bool
 			origLogFatal   func(args ...interface{})
@@ -152,18 +150,18 @@ func testClusterNamesOrAll() {
 		})
 	})
 
-	When("directory exists", func() {
+	When("the directory exists", func() {
 		BeforeEach(createStubDirectory)
 
 		AfterEach(deleteStubDirectory)
 
-		When("the directory is empty", func() {
+		Context("and is empty", func() {
 			It("should return an empty slice", func() {
 				Expect(len(clusters)).To(Equal(0))
 			})
 		})
 
-		When("the directory has files", func() {
+		Context("and contains files", func() {
 			var expectedClusters = []string{"cluster1", "cluster2", "cluster42"}
 			BeforeEach(func() {
 				generateClusterFiles(expectedClusters)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"io/ioutil"
+	"log"
+	"strings"
+
+	"github.com/submariner-io/armada/pkg/defaults"
+)
+
+// ClusterNamesFromFiles will return all clusters from the existing kind files.
+// An error is returned if there's a failure to read the config directory.
+func ClusterNamesFromFiles() ([]string, error) {
+	var clusters []string
+	files, err := ioutil.ReadDir(defaults.KindConfigDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		clusterName := strings.FieldsFunc(file.Name(), func(r rune) bool { return strings.ContainsRune(" -.", r) })[2]
+		clusters = append(clusters, clusterName)
+	}
+
+	return clusters, nil
+}
+
+// ClusterNamesOrAll will return the cluster names sent to it, if there are any.
+// In case the slice is empty, it will read the cluster names from the existing kind files.
+// Should the read fail, it will fatally log the error (causing the process to abort).
+func ClusterNamesOrAll(clusters []string) []string {
+	if len(clusters) > 0 {
+		return clusters
+	}
+
+	clusters, err := ClusterNamesFromFiles()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return clusters
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,33 +34,7 @@ func CreateEnvironment(flags *clustercmd.CreateFlagpole, provider *kind.Provider
 	log.SetLevel(log.DebugLevel)
 	box := packr.New("configs", "../../configs")
 
-	targetClusters, err := clustercmd.GetTargetClusters(provider, flags)
-	if err != nil {
-		return nil, err
-	}
-
-	tasks := []func() error{}
-	for _, c := range targetClusters {
-		clusterName := c
-		tasks = append(tasks, func() error {
-			return cluster.Create(clusterName, provider, box)
-		})
-	}
-
-	err = wait.ForTasksComplete(defaults.WaitDurationResources, tasks...)
-	if err != nil {
-		return nil, err
-	}
-
-	tasks = []func() error{}
-	for _, c := range targetClusters {
-		clusterName := c
-		tasks = append(tasks, func() error {
-			return cluster.FinalizeSetup(clusterName, box)
-		})
-	}
-
-	err = wait.ForTasksComplete(defaults.WaitDurationResources, tasks...)
+	targetClusters, err := clustercmd.CreateClusters(flags, provider, box)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -70,9 +69,9 @@ var _ = Describe("E2E Tests", func() {
 			clusters, err := CreateEnvironment(flags, provider)
 			Ω(err).ShouldNot(HaveOccurred())
 
-			cl1Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(1), provider)
+			cl1Status, err := cluster.IsKnown(utils.ClusterName(1), provider)
 			Ω(err).ShouldNot(HaveOccurred())
-			cl2Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(2), provider)
+			cl2Status, err := cluster.IsKnown(utils.ClusterName(2), provider)
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Expect(cl1Status).Should(BeTrue())
@@ -80,25 +79,25 @@ var _ = Describe("E2E Tests", func() {
 			Expect(clusters).Should(Equal([]*cluster.Config{
 				{
 					Cni:                 "flannel",
-					Name:                defaults.ClusterNameBase + strconv.Itoa(1),
+					Name:                utils.ClusterName(1),
 					PodSubnet:           "10.0.0.0/14",
 					ServiceSubnet:       "100.0.0.0/16",
-					DNSDomain:           defaults.ClusterNameBase + strconv.Itoa(1) + ".local",
+					DNSDomain:           utils.ClusterName(1) + ".local",
 					KubeAdminAPIVersion: defaults.KubeAdminAPIVersion,
 					NumWorkers:          defaults.NumWorkers,
-					KubeConfigFilePath:  filepath.Join(usr.HomeDir, ".kube", "kind-config-"+defaults.ClusterNameBase+strconv.Itoa(1)),
+					KubeConfigFilePath:  filepath.Join(usr.HomeDir, ".kube", "kind-config-"+utils.ClusterName(1)),
 					Retain:              false,
 					WaitForReady:        0,
 				},
 				{
 					Cni:                 "flannel",
-					Name:                defaults.ClusterNameBase + strconv.Itoa(2),
+					Name:                utils.ClusterName(2),
 					PodSubnet:           "10.0.0.0/14",
 					ServiceSubnet:       "100.0.0.0/16",
-					DNSDomain:           defaults.ClusterNameBase + strconv.Itoa(2) + ".local",
+					DNSDomain:           utils.ClusterName(2) + ".local",
 					KubeAdminAPIVersion: defaults.KubeAdminAPIVersion,
 					NumWorkers:          defaults.NumWorkers,
-					KubeConfigFilePath:  filepath.Join(usr.HomeDir, ".kube", "kind-config-"+defaults.ClusterNameBase+strconv.Itoa(2)),
+					KubeConfigFilePath:  filepath.Join(usr.HomeDir, ".kube", "kind-config-"+utils.ClusterName(2)),
 					Retain:              false,
 					WaitForReady:        0,
 				},
@@ -123,14 +122,14 @@ var _ = Describe("E2E Tests", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 
 			containerFilter := filters.NewArgs()
-			containerFilter.Add("name", defaults.ClusterNameBase+strconv.Itoa(3)+"-control-plane")
+			containerFilter.Add("name", utils.ClusterName(3)+"-control-plane")
 			container, err := dockerCli.ContainerList(ctx, dockertypes.ContainerListOptions{
 				Filters: containerFilter,
 				Limit:   1,
 			})
 			Ω(err).ShouldNot(HaveOccurred())
 			image := container[0].Image
-			cl3Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(3), provider)
+			cl3Status, err := cluster.IsKnown(utils.ClusterName(3), provider)
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Expect(image).Should(Equal(flags.ImageName))
@@ -138,13 +137,13 @@ var _ = Describe("E2E Tests", func() {
 			Expect(clusters).Should(Equal([]*cluster.Config{
 				{
 					Cni:                 "weave",
-					Name:                defaults.ClusterNameBase + strconv.Itoa(3),
+					Name:                utils.ClusterName(3),
 					PodSubnet:           "10.12.0.0/14",
 					ServiceSubnet:       "100.3.0.0/16",
-					DNSDomain:           defaults.ClusterNameBase + strconv.Itoa(3) + ".local",
+					DNSDomain:           utils.ClusterName(3) + ".local",
 					KubeAdminAPIVersion: "kubeadm.k8s.io/v1beta2",
 					NumWorkers:          defaults.NumWorkers,
-					KubeConfigFilePath:  filepath.Join(usr.HomeDir, ".kube", "kind-config-"+defaults.ClusterNameBase+strconv.Itoa(3)),
+					KubeConfigFilePath:  filepath.Join(usr.HomeDir, ".kube", "kind-config-"+utils.ClusterName(3)),
 					WaitForReady:        0,
 					NodeImageName:       "kindest/node:v1.15.6",
 					Retain:              false,
@@ -156,7 +155,7 @@ var _ = Describe("E2E Tests", func() {
 		It("Should not create a new cluster", func() {
 			numClusters := 3
 			for i := 1; i <= numClusters; i++ {
-				clName := defaults.ClusterNameBase + strconv.Itoa(i)
+				clName := utils.ClusterName(i)
 				known, err := cluster.IsKnown(clName, provider)
 				Ω(err).ShouldNot(HaveOccurred())
 				if known {
@@ -337,8 +336,8 @@ var _ = Describe("E2E Tests", func() {
 
 			images := []string{"nginx:stable-alpine", "alpine:latest"}
 			clusters := []string{
-				defaults.ClusterNameBase + strconv.Itoa(1),
-				defaults.ClusterNameBase + strconv.Itoa(3),
+				utils.ClusterName(1),
+				utils.ClusterName(3),
 			}
 
 			var nodesWithImage uint32
@@ -377,7 +376,7 @@ var _ = Describe("E2E Tests", func() {
 	})
 	Context("Cluster deletion", func() {
 		It("Should destroy clusters 1 and 3 only", func() {
-			clusters := []string{defaults.ClusterNameBase + strconv.Itoa(1), defaults.ClusterNameBase + strconv.Itoa(3)}
+			clusters := []string{utils.ClusterName(1), utils.ClusterName(3)}
 			for _, clName := range clusters {
 				known, err := cluster.IsKnown(clName, provider)
 				Ω(err).ShouldNot(HaveOccurred())
@@ -387,11 +386,11 @@ var _ = Describe("E2E Tests", func() {
 				}
 			}
 
-			cl1Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(1), provider)
+			cl1Status, err := cluster.IsKnown(utils.ClusterName(1), provider)
 			Ω(err).ShouldNot(HaveOccurred())
-			cl2Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(2), provider)
+			cl2Status, err := cluster.IsKnown(utils.ClusterName(2), provider)
 			Ω(err).ShouldNot(HaveOccurred())
-			cl3Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(3), provider)
+			cl3Status, err := cluster.IsKnown(utils.ClusterName(3), provider)
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Expect(cl1Status).Should(BeFalse())
@@ -407,11 +406,11 @@ var _ = Describe("E2E Tests", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 			}
 
-			cl1Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(1), provider)
+			cl1Status, err := cluster.IsKnown(utils.ClusterName(1), provider)
 			Ω(err).ShouldNot(HaveOccurred())
-			cl2Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(2), provider)
+			cl2Status, err := cluster.IsKnown(utils.ClusterName(2), provider)
 			Ω(err).ShouldNot(HaveOccurred())
-			cl3Status, err := cluster.IsKnown(defaults.ClusterNameBase+strconv.Itoa(3), provider)
+			cl3Status, err := cluster.IsKnown(utils.ClusterName(3), provider)
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Expect(cl1Status).Should(BeFalse())


### PR DESCRIPTION
As part of overhauling the create command, I've noticed that the cluster name extraction logic is copied all over the place.
As such I've moved it into a common utils package and reused it where needed