### PR TITLE
Use errors.Wrap where appropriate

### DIFF
--- a/cmd/cluster/create.go
+++ b/cmd/cluster/create.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gobuffalo/packr/v2"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/armada/pkg/cluster"
@@ -87,11 +88,7 @@ func CreateClusters(flags *CreateFlagpole, provider *kind.Provider, box *packr.B
 		config := c
 		tasks = append(tasks, func() error {
 			err := cluster.Create(config, provider, box)
-			if err != nil {
-				return fmt.Errorf("Error creating cluster %q", config.Name)
-			}
-
-			return nil
+			return errors.Wrapf(err, "Error creating cluster %q", config.Name)
 		})
 	}
 
@@ -107,11 +104,7 @@ func CreateClusters(flags *CreateFlagpole, provider *kind.Provider, box *packr.B
 		config := c
 		tasks = append(tasks, func() error {
 			err := cluster.FinalizeSetup(config, box)
-			if err != nil {
-				return fmt.Errorf("Error finalizing cluster %q", config.Name)
-			}
-
-			return nil
+			return errors.Wrapf(err, "Error finalizing cluster %q", config.Name)
 		})
 	}
 

--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -2,11 +2,11 @@ package image
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	dockerclient "github.com/docker/docker/client"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/submariner-io/armada/pkg/defaults"
@@ -70,11 +70,7 @@ func NewLoadCommand(provider *kind.Provider) *cobra.Command {
 					node := n
 					tasks = append(tasks, func() error {
 						err := image.LoadToNode(imageTarPath, imageName, node)
-						if err != nil {
-							return fmt.Errorf("Error loading image %q to node %q", imageName, node.String())
-						}
-
-						return nil
+						return errors.Wrapf(err, "Error loading image %q to node %q", imageName, node.String())
 					})
 				}
 


### PR DESCRIPTION
Since errors.Wrap would return nil if the error is nil, we can safetly
use it in simple cases instead of having boilerplate checks for error.